### PR TITLE
Update cops to specify department where missing

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -9,7 +9,7 @@ AllCops:
     - 'bin/**/*' # don't lint generated bin/scripts
 
 # Don't enforce comments classes
-Documentation:
+Style/Documentation:
   Enabled: false
 
 Layout/EmptyLineAfterMagicComment:
@@ -74,7 +74,7 @@ Metrics/LineLength:
     - 'spec/**/*'
 
 # Disable multi-line chaining check
-MultilineBlockChain:
+Style/MultilineBlockChain:
   Enabled: false
 
 # Allow method names starting with get or set

--- a/lib/citizens-advice/style/version.rb
+++ b/lib/citizens-advice/style/version.rb
@@ -2,6 +2,6 @@
 
 module CitizensAdvice
   module Style
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end


### PR DESCRIPTION
Rubocop seems to require a department for each cop, eg instead of just `CyclomaticComplexity`, must use `Metrics/CyclomaticComplexity`