### PR TITLE
Update obsolete configuration

### DIFF
--- a/default-rails.yml
+++ b/default-rails.yml
@@ -50,6 +50,9 @@ Lint/ParenthesesAsGroupedExpression:
 
 # rubocop-rails rules
 
+Rails/FilePath:
+  EnforcedStyle: 'arguments'
+
 Rails/SkipsModelValidations:
   Exclude:
     - 'features/**/*'

--- a/default-rails.yml
+++ b/default-rails.yml
@@ -50,9 +50,6 @@ Lint/ParenthesesAsGroupedExpression:
 
 # rubocop-rails rules
 
-Rails/FilePath:
-  EnforcedStyle: 'arguments'
-
 Rails/SkipsModelValidations:
   Exclude:
     - 'features/**/*'

--- a/default.yml
+++ b/default.yml
@@ -32,11 +32,11 @@ Style/FormatStringToken:
   EnforcedStyle: template # Prefer simple looking "template" style tokens like `%{name}`, `%{age}`
 
 # More flexible array alignment
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
 # More flexible hash alignment
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
 Layout/MultilineMethodCallIndentation:
@@ -84,7 +84,7 @@ Naming/AccessorMethodName:
 Naming/MemoizedInstanceVariableName:
   Enabled: false
 
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   AllowedNames:
     - '_'
     - 'e'

--- a/lib/citizens-advice/style/version.rb
+++ b/lib/citizens-advice/style/version.rb
@@ -2,6 +2,6 @@
 
 module CitizensAdvice
   module Style
-    VERSION = "0.2.1"
+    VERSION = "0.2.2"
   end
 end


### PR DESCRIPTION
The default file path style now defaults to `Rails.root.join('app/models/goober')`, which I prefer.
Should we stick to the old arguments style?

https://docs.rubocop.org/projects/rails/en/stable/cops_rails/#railsfilepath
https://github.com/rubocop-hq/rubocop/issues/5823