### PR TITLE
Pinned rubocop version to match config

### DIFF
--- a/citizens-advice-style.gemspec
+++ b/citizens-advice-style.gemspec
@@ -36,5 +36,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.70"
+  # A working configuration can suddenly become a problem if rubocop deprecates or changes
+  # cop names. Allowing just patch updates should prevent this happening.
+  # When rubocop is upgraded here, this gem should get a minor version update as well.
+  spec.add_dependency "rubocop", "~> 0.80.0"
 end

--- a/lib/citizens-advice/style/version.rb
+++ b/lib/citizens-advice/style/version.rb
@@ -2,6 +2,6 @@
 
 module CitizensAdvice
   module Style
-    VERSION = "0.2.4"
+    VERSION = "0.2.5"
   end
 end


### PR DESCRIPTION
I had a problem with the infra-components gem which is using this one - adding the rubocop development dependency directly was leading to a mismatch between the inherited config and the running version. Without specifying the rubocop version, I was getting version 0.81.0 which has new configuration needs.

Have added comments which should explain what needs to happen next time rubocop gets upgraded.