### PR TITLE
Update Rubocop - Enable newcops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 .repl_history
 build/
 
+# IDE
+.idea/*
+
 ## Documentation cache and generated files:
 /.yardoc/
 /_yardoc/

--- a/citizens-advice-style.gemspec
+++ b/citizens-advice-style.gemspec
@@ -39,5 +39,5 @@ Gem::Specification.new do |spec|
   # A working configuration can suddenly become a problem if rubocop deprecates or changes
   # cop names. Allowing just patch updates should prevent this happening.
   # When rubocop is upgraded here, this gem should get a minor version update as well.
-  spec.add_dependency "rubocop", "~> 0.80.0"
+  spec.add_dependency "rubocop", "~> 0.85.1"
 end

--- a/default.yml
+++ b/default.yml
@@ -8,6 +8,10 @@ AllCops:
   Exclude:
     - 'bin/**/*' # don't lint generated bin/scripts
 
+  # Since Rubocop v0.83 - New cops introduced can be auto-enabled / disabled
+  # Lets remove the warnings for these
+  NewCops: enable
+
 # Don't enforce comments classes
 Style/Documentation:
   Enabled: false
@@ -92,12 +96,3 @@ Naming/MethodParameterName:
 # Prefer double quotes
 Style/StringLiterals:
   EnforcedStyle: double_quotes
-
-Style/HashEachMethods:
-  Enabled: true
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true

--- a/lib/citizens-advice/style/version.rb
+++ b/lib/citizens-advice/style/version.rb
@@ -2,6 +2,6 @@
 
 module CitizensAdvice
   module Style
-    VERSION = "0.2.5"
+    VERSION = "0.3.0"
   end
 end


### PR DESCRIPTION
This will implicitly remove all warnings. It also gives us some future proofing to avoid having to "re-add" loads of new stuff each time they go :bangbang:

I've auto bumped to 0.3 in the gem. I looked at previous commits and it seems as though it's done in the same PR as the changes. Hope this is ok.