### PR TITLE
FIX Add missing did you mean gem

### DIFF
--- a/citizens-advice-style.gemspec
+++ b/citizens-advice-style.gemspec
@@ -39,9 +39,9 @@ Gem::Specification.new do |spec|
   # A working configuration can suddenly become a problem if rubocop deprecates or changes
   # cop names. Allowing just patch updates should prevent this happening.
   # When rubocop is upgraded here, this gem should get a minor version update as well.
-  spec.add_dependency "rubocop", "~> 0.85.1"
+  spec.add_dependency "rubocop", "~> 0.87.0"
   
   # In earlier versions, rubocop could find the DidYouMean module through ruby's default gems.
   # This seems to have changed so that it must now be added to the Gemfile.
-  spec.add_dependency "did_you_mean", "~> 1.4.0"
+  # spec.add_dependency "did_you_mean", "~> 1.4.0"
 end

--- a/citizens-advice-style.gemspec
+++ b/citizens-advice-style.gemspec
@@ -40,8 +40,4 @@ Gem::Specification.new do |spec|
   # cop names. Allowing just patch updates should prevent this happening.
   # When rubocop is upgraded here, this gem should get a minor version update as well.
   spec.add_dependency "rubocop", "~> 0.87.0"
-  
-  # In earlier versions, rubocop could find the DidYouMean module through ruby's default gems.
-  # This seems to have changed so that it must now be added to the Gemfile.
-  # spec.add_dependency "did_you_mean", "~> 1.4.0"
 end

--- a/citizens-advice-style.gemspec
+++ b/citizens-advice-style.gemspec
@@ -40,4 +40,8 @@ Gem::Specification.new do |spec|
   # cop names. Allowing just patch updates should prevent this happening.
   # When rubocop is upgraded here, this gem should get a minor version update as well.
   spec.add_dependency "rubocop", "~> 0.85.1"
+  
+  # In earlier versions, rubocop could find the DidYouMean module through ruby's default gems.
+  # This seems to have changed so that it must now be added to the Gemfile.
+  spec.add_dependency "did_you_mean", "~> 1.4.0"
 end

--- a/lib/citizens-advice/style/version.rb
+++ b/lib/citizens-advice/style/version.rb
@@ -2,6 +2,6 @@
 
 module CitizensAdvice
   module Style
-    VERSION = "0.3.0"
+    VERSION = "0.3.1"
   end
 end


### PR DESCRIPTION
In adding version 0.3.0 to the devops repositories, I noticed that there was an error in the VariableForce cop.

This turns out to be related to an issue with [rubocop not being able to find the DidYouMean module](https://github.com/rubocop-hq/rubocop/issues/7979). It has been a default module for some time, but for some reason has been removed and is now required in the Gemfile.