### PR TITLE
Update citizens-advice-style.gemspec

### DIFF
--- a/citizens-advice-style.gemspec
+++ b/citizens-advice-style.gemspec
@@ -39,5 +39,5 @@ Gem::Specification.new do |spec|
   # A working configuration can suddenly become a problem if rubocop deprecates or changes
   # cop names. Allowing just patch updates should prevent this happening.
   # When rubocop is upgraded here, this gem should get a minor version update as well.
-  spec.add_dependency "rubocop", "~> 0.87.0"
+  spec.add_dependency "rubocop", "~> 0.91.0"
 end

--- a/lib/citizens-advice/style/version.rb
+++ b/lib/citizens-advice/style/version.rb
@@ -2,6 +2,6 @@
 
 module CitizensAdvice
   module Style
-    VERSION = "0.3.2"
+    VERSION = "0.4.0"
   end
 end

--- a/lib/citizens-advice/style/version.rb
+++ b/lib/citizens-advice/style/version.rb
@@ -2,6 +2,6 @@
 
 module CitizensAdvice
   module Style
-    VERSION = "0.3.1"
+    VERSION = "0.3.2"
   end
 end


### PR DESCRIPTION
Update to rubocop 0.91 to resolve rubocop errors in the LineLength cop