### PR TITLE
Bump rubocop required version to ~> 1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## <sub>v1.1.0</sub>
 
-#### _Nov. 26 2020_
+#### _Jan. 15 2021_
 
 **Updates**:
 * Gem now uses version 1.3 of rubocop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Citizens Advice Style Ruby
 
+## <sub>v1.1.0</sub>
+
+#### _Nov. 26 2020_
+
+**Updates**:
+* Gem now uses version 1.3 of rubocop
+
 ## <sub>v1.0.0</sub>
 
 #### _Nov. 26 2020_

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/citize
 
 ## Releasing
 
-1. Make changes and test locally
+1. Run `rubocop` locally, to validate structure of yml files.
 2. Update `lib/citizens-advice/style/version.rb` with appropriate new version number
-3. Create release branch and push changes to github
-4. After review & merge, tag the version on Github so people can reference it as a new package
+3. Create release branch and push changes up to github
+4. After review & merge, tag the version on github so people can reference it as a new package

--- a/citizens-advice-style.gemspec
+++ b/citizens-advice-style.gemspec
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "citizens-advice/style/version"
@@ -8,32 +9,21 @@ Gem::Specification.new do |spec|
   spec.version       = CitizensAdvice::Style::VERSION
   spec.author        = "Citizens Advice"
   spec.email         = %w[robert.murray@citizensadvice.org.uk luke.hill@citizensadvice.org.uk]
-
   spec.summary       = "Citizens Advice shared rubocop configuration"
   spec.homepage      = "https://github.com/citizensadvice/citizens-advice-style-ruby"
 
   spec.required_ruby_version = ">= 2.7"
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
-
-    spec.metadata["homepage_uri"] = spec.homepage
-    spec.metadata["source_code_uri"] = "https://github.com/citizensadvice/citizens-advice-style-ruby"
-    spec.metadata["changelog_uri"] = "https://github.com/citizensadvice/citizens-advice-style-ruby"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/citizensadvice/citizens-advice-style-ruby"
+  spec.metadata["changelog_uri"] = "https://github.com/citizensadvice/citizens-advice-style-ruby/blob/master/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 1.0.0"
+  spec.add_dependency "rubocop", "~> 1.3.0"
 end

--- a/lib/citizens-advice/style/version.rb
+++ b/lib/citizens-advice/style/version.rb
@@ -2,6 +2,6 @@
 
 module CitizensAdvice
   module Style
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
   end
 end


### PR DESCRIPTION
Opted to pick 1.3 as it's a sizeable update but also starts using some more of the new sub-gems (Such as the enhanced parser and ast). Can always bump it again in another version.