### PR TITLE
Feature/v2 old removals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,16 @@
 
 #### _Unreleased_
 
-**Updates**:
-*
+**Breaking changes**:
+* Removed all V2 (TOFIX), cops.
+  * `Metrics/LineLength` is now set to 140, with no exceptions
+  * `Lint/AmbiguousBlockAssociation` is now enabled
+  * `Naming/MemoizedInstanceVariableName` is now enabled
+  * `Naming/MethodParameterName` has had the redundant ignores removed
+  * `Style/MultilineBlockChain` is now enabled
+
+**Fixes**:
+* Re-added in `NewCops: enabled` as this is used in rubocop 1.x as well
 
 ## <sub>v1.2.0</sub>
 

--- a/default.yml
+++ b/default.yml
@@ -19,16 +19,8 @@ Layout/FirstArrayElementIndentation:
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
-# 140 character width
-# TOFIX: Remove Exclude in V2
 Layout/LineLength:
   Max: 140
-  Exclude:
-    - 'spec/**/*'
-
-# TOFIX: Remove in V2
-Lint/AmbiguousBlockAssociation:
-  Enabled: false
 
 # Exclude BlockLength from spec tests as this will break all spec tests.
 # It should be added to the rubocop-rspec defaults ideally.
@@ -38,10 +30,6 @@ Metrics/BlockLength:
 
 # Allow method names starting with get or set, as we use some DSL's
 Naming/AccessorMethodName:
-  Enabled: false
-
-# TOFIX: Remove in V2
-Naming/MemoizedInstanceVariableName:
   Enabled: false
 
 # TOFIX: Document / Discuss in V2

--- a/default.yml
+++ b/default.yml
@@ -1,9 +1,11 @@
 AllCops:
-  # Target Ruby 2.7 only
-  TargetRubyVersion: 2.7
   # Display all verbose info on failures to help people triage how to fix
   DisplayCopNames: true
   DisplayStyleGuide: true
+  # Enable all NewCops by default (Even new 1.x cops)
+  NewCops: enable
+  # Target Ruby 2.7 only
+  TargetRubyVersion: 2.7
   # Don't lint bin/scripts - Possibly remove for V2
   # Don't lint package files
   Exclude:

--- a/default.yml
+++ b/default.yml
@@ -49,11 +49,6 @@ Style/Documentation:
 Style/FormatStringToken:
   EnforcedStyle: template
 
-# Disable multi-line chaining check
-# TOFIX: Document / Discuss in V2
-Style/MultilineBlockChain:
-  Enabled: false
-
 # Prefer Double quotes in Ruby across the codebase/s
 Style/StringLiterals:
   EnforcedStyle: double_quotes

--- a/default.yml
+++ b/default.yml
@@ -19,6 +19,7 @@ Layout/FirstArrayElementIndentation:
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
+# We have a linelength of 140 characters across the codebase/s
 Layout/LineLength:
   Max: 140
 
@@ -35,11 +36,8 @@ Naming/AccessorMethodName:
 # TOFIX: Document / Discuss in V2
 Naming/MethodParameterName:
   AllowedNames:
-    - '_'
     - 'e'
     - 'i'
-    - 'id'
-    - 'to'
 
 # We don't enforce documentation comments on Modules/Classes
 Style/Documentation:


### PR DESCRIPTION
So in preparation for a v2 release of our gem Let's cut away a load of old crud again.

All of the following shouldn't be controversial, as it's stuff we previously said we would remove.

To start with I've removed everything we've said we should remove (But didn't for V1 to not make it too big)
I then re-added NewCops: enable. Apparently this is still being used (Shouldn't have removed this previously).
Also for MethodParameterName `_` would never flag (Nor would it on any other type of offense, it's a magic variable in ruby), and `id` and `to` are permissible as param names according to the rubocop whitelist.