### PR TITLE
Feature/discussion v2 removals

### DIFF
--- a/default-rails.yml
+++ b/default-rails.yml
@@ -15,10 +15,6 @@ AllCops:
     - '**/*/Brewfile'
     - 'db/migrate/*'
 
-Layout/LineLength:
-  Exclude:
-    - 'features/**/*'
-
 Lint/ParenthesesAsGroupedExpression:
   Exclude:
     - 'features/step_definitions/**/*'

--- a/default-rails.yml
+++ b/default-rails.yml
@@ -23,11 +23,6 @@ Lint/ParenthesesAsGroupedExpression:
   Exclude:
     - 'features/step_definitions/**/*'
 
-Metrics/AbcSize:
-  Exclude:
-    - 'features/**/*'
-    - 'spec/**/*'
-
 Metrics/BlockLength:
   Exclude:
     - 'config/**/*'
@@ -39,10 +34,6 @@ Metrics/ClassLength:
   Exclude:
     - 'features/**/*'
     - 'spec/**/*'
-
-Metrics/MethodLength:
-  Exclude:
-    - 'features/**/*'
 
 # Migrations using `change_table` with `bulk: true` can improve some db platform migration performance
 # but it also introduces some other issues as it does not support all features that add_column,

--- a/default.yml
+++ b/default.yml
@@ -22,6 +22,10 @@ Layout/FirstHashElementIndentation:
 # We have a linelength of 140 characters across the codebase/s
 Layout/LineLength:
   Max: 140
+  Exclude:
+    - '^Given'
+    - '^When'
+    - '^Then'
 
 # Exclude BlockLength from spec tests as this will break all spec tests.
 # It should be added to the rubocop-rspec defaults ideally.

--- a/default.yml
+++ b/default.yml
@@ -6,10 +6,8 @@ AllCops:
   NewCops: enable
   # Target Ruby 2.7 only
   TargetRubyVersion: 2.7
-  # Don't lint bin/scripts - Possibly remove for V2
   # Don't lint package files
   Exclude:
-    - bin/**/*
     - vendor/**/*
     - node_modules/**/*
 
@@ -34,12 +32,6 @@ Metrics/BlockLength:
 # Allow method names starting with get or set, as we use some DSL's
 Naming/AccessorMethodName:
   Enabled: false
-
-# TOFIX: Document / Discuss in V2
-Naming/MethodParameterName:
-  AllowedNames:
-    - 'e'
-    - 'i'
 
 # We don't enforce documentation comments on Modules/Classes
 Style/Documentation:


### PR DESCRIPTION
So here are the final removals in v2 that are likely to prompt more discussion (We can also remove / amend more if needs be)

From default config:
- Lint all of bin/scripts with all rules (Think @mrdaniellewis mentioned we should do this)
- `Naming/MethodParameterName`: Final 2 removals which weren't whitelisted. Ideally we shouldn't be using single char block names. Use `&:` notification on simple stuff

From rails config:
- `Layout/LineLength`: (I've allowed gherkin definitions to go over the limit, but gherkin bodies in theory shouldn't (Same as regular ruby)
- `Metrics/AbcSize`: The only offenses here were in test files, but in theory this is a really bad metric to go over. If we do need 1 or 2 manual overrides that is fine, but by and large we "shouldn't" be ignoring this rule.
- `Metrics/MethodLength`: Same as above