### PR TITLE
Relax required ruby version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Citizens Advice Style Ruby
 
+## v6.0.0
+
+_Jan. 12 2022_
+
+**Updates**:
+
+* Gem now uses v1.24 of rubocop
+* Gem now uses v2.7 of rubocop-rspec
+* Removed required ruby version
+
 ## v5.0.0
 
 _Dec. 13 2021_

--- a/citizens-advice-style.gemspec
+++ b/citizens-advice-style.gemspec
@@ -7,7 +7,7 @@ require "citizens-advice/style/version"
 Gem::Specification.new do |spec|
   spec.name          = "citizens-advice-style"
   spec.version       = CitizensAdvice::Style::VERSION
-  spec.authors       = ["Robert Murray", "Luke Hill", "Daniel Lewis"]
+  spec.authors       = ["Robert Murray", "Luke Hill", "Daniel Lewis", "David Rapson"]
   spec.summary       = "Citizens Advice shared rubocop configuration"
   spec.homepage      = "https://github.com/citizensadvice/citizens-advice-style-ruby"
   spec.license       = "MIT"
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 1.23.0"
-  spec.add_dependency "rubocop-rspec", "~> 2.6.0"
+  spec.add_dependency "rubocop", "~> 1.24.1"
+  spec.add_dependency "rubocop-rspec", "~> 2.7.0"
 end

--- a/citizens-advice-style.gemspec
+++ b/citizens-advice-style.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/citizensadvice/citizens-advice-style-ruby"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">=3.0.3"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/citizensadvice/citizens-advice-style-ruby"

--- a/default.yml
+++ b/default.yml
@@ -12,7 +12,6 @@ AllCops:
   DisplayStyleGuide: true
   # Enable all NewCops by default (Even new 1.x cops)
   NewCops: enable
-  TargetRubyVersion: 3
   # Don't lint package files
   Exclude:
     - vendor/**/*

--- a/lib/citizens-advice/style/version.rb
+++ b/lib/citizens-advice/style/version.rb
@@ -2,6 +2,6 @@
 
 module CitizensAdvice
   module Style
-    VERSION = "5.0.0"
+    VERSION = "6.0.0"
   end
 end


### PR DESCRIPTION
A recent change restricted the required ruby version for this project to 3.0.3 or above. We have a few projects running on 2.7 and notably the design-system tests against both 2.7 and 3. Limiting the version to 3 prevents us from using the new version in these contexts.

The rubocop docs for TargetRubyVersion suggest that this respects the project value if this is unset:

> Otherwise, RuboCop will then check your project for a series of files where the version may be specified already. The files that will be looked for are .ruby-version, Gemfile.lock, and *.gemspec. If Gemspec file has an array for required_ruby_version, the lowest version will be used. If none of the files are found a default version value will be used.

https://docs.rubocop.org/rubocop/configuration.html#setting-the-target-ruby-version

As the ruby version is a project specific thing it makes sense to defer to the project rather than explicitly setting this in shared rules.

This change removes `TargetRubyVersion` and widens the `required_ruby_version` again so we can continue to use this config against 2.7 versions of ruby.

Shout if I've misunderstood the intent of the original change.