### PR TITLE
11.0.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,4 +2,4 @@ inherit_from: default.yml
 
 AllCops:
   # Match minimum target version to gemspec
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1.4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,4 +2,4 @@ inherit_from: default.yml
 
 AllCops:
   # Match minimum target version to gemspec
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Citizens Advice Style Ruby
 
+## v11.0.0
+
+- Include rubocop-performance
+- Drop ruby 2.7 support
+- Bump dependency versions to latest
+
 ## v10.0.1
 
 - Now includes the correct version number
@@ -8,11 +14,11 @@
 
 **Updates**:
 
-* Remove `spec/` exclude for `Metrics/BlockLength` as this is now a default in rubocop-rspec 2.11+
-* Gem now requires version `~> 1.45` of rubocop
-* Gem now requires version `~> 2.18` of rubocop-rspec
-* Add rubocop-rails as as dependency using `~> 2.17`
-* Count arrays and hashes as one-line when calculating method and class length
+- Remove `spec/` exclude for `Metrics/BlockLength` as this is now a default in rubocop-rspec 2.11+
+- Gem now requires version `~> 1.45` of rubocop
+- Gem now requires version `~> 2.18` of rubocop-rspec
+- Add rubocop-rails as as dependency using `~> 2.17`
+- Count arrays and hashes as one-line when calculating method and class length
 
 ## v9.0.0
 
@@ -20,8 +26,8 @@ _Jun. 17 2022_
 
 **Updates**:
 
-* Gem now uses v1.30 of rubocop
-* Gem now uses v2.11 of rubocop-rspec
+- Gem now uses v1.30 of rubocop
+- Gem now uses v2.11 of rubocop-rspec
 
 ## v8.0.0
 
@@ -29,8 +35,8 @@ _May. 5 2022_
 
 **Updates**:
 
-* Gem now uses v1.28 of rubocop
-* Gem now uses v2.10 of rubocop-rspec
+- Gem now uses v1.28 of rubocop
+- Gem now uses v2.10 of rubocop-rspec
 
 ## v7.0.0
 
@@ -38,8 +44,8 @@ _Feb. 25 2022_
 
 **Updates**:
 
-* Gem now uses v1.25 of rubocop
-* Gem now uses v2.8 of rubocop-rspec
+- Gem now uses v1.25 of rubocop
+- Gem now uses v2.8 of rubocop-rspec
 
 ## v6.0.0
 
@@ -47,9 +53,9 @@ _Jan. 12 2022_
 
 **Updates**:
 
-* Gem now uses v1.24 of rubocop
-* Gem now uses v2.7 of rubocop-rspec
-* Removed required ruby version
+- Gem now uses v1.24 of rubocop
+- Gem now uses v2.7 of rubocop-rspec
+- Removed required ruby version
 
 ## v5.0.0
 
@@ -57,98 +63,112 @@ _Dec. 13 2021_
 
 **Updates**:
 
-* Gem now uses v1.23 of rubocop
-* (Re)Enabled Rails/HasManyOrHasOneDependent
-* Additional exclusions for Rails migrations
- 
+- Gem now uses v1.23 of rubocop
+- (Re)Enabled Rails/HasManyOrHasOneDependent
+- Additional exclusions for Rails migrations
+
 **Breaking changes**:
 
-* Requires Ruby 3.0.3
-* Includes rubocop-rspec by default
+- Requires Ruby 3.0.3
+- Includes rubocop-rspec by default
 
 ## v4.1.0
 
 _Sep. 23 2021_
 
 **Updates**:
-* Gem now uses v1.21 of rubocop
+
+- Gem now uses v1.21 of rubocop
 
 ## v4.0.0
 
 _Sep. 14 2021_
 
 **Breaking changes**:
-* Removed final undocumented exclusions from `default-rails.yml`
-  * Brewfile's shouldn't be monitored in this gem
-  * Rails migration's should conform to standard linting
+
+- Removed final undocumented exclusions from `default-rails.yml`
+  - Brewfile's shouldn't be monitored in this gem
+  - Rails migration's should conform to standard linting
 
 **Fixes**
-* Removed the need for git when determining files included in gem
+
+- Removed the need for git when determining files included in gem
 
 **Updates**:
-* Gem now uses v1.20 of rubocop
+
+- Gem now uses v1.20 of rubocop
 
 ## v3.0.1
 
 _Aug. 12 2021_
 
 **Fixes**
-* Moved the merge exclude rule from rails config to default config
+
+- Moved the merge exclude rule from rails config to default config
 
 ## v3.0.0
 
 _Jul. 26 2021_
 
 **Breaking changes**:
-* Removed all testing based ignores
-  * `Lint/ParenthesesAsGroupedExpression` is no longer ignored
-  * `Metrics/ClassLength` is no longer ignored
-  * `Metrics/BlockLength` has been removed from being ignored in test locations (But is still overridden a few times)
-  * `Rails/SkipsModelValidations` is no longer ignored
 
-* Some of `Metrics/BlockLength` overrides which were flagged as rails based are now moved into the core `default.yml`
+- Removed all testing based ignores
+
+  - `Lint/ParenthesesAsGroupedExpression` is no longer ignored
+  - `Metrics/ClassLength` is no longer ignored
+  - `Metrics/BlockLength` has been removed from being ignored in test locations (But is still overridden a few times)
+  - `Rails/SkipsModelValidations` is no longer ignored
+
+- Some of `Metrics/BlockLength` overrides which were flagged as rails based are now moved into the core `default.yml`
 
 **Updates**:
-* Gem now uses v1.18 of rubocop
+
+- Gem now uses v1.18 of rubocop
 
 ## v2.1.0
 
 _Mar. 6 2021_
 
 **Updates**:
-* Gem now uses v1.11 of rubocop
+
+- Gem now uses v1.11 of rubocop
 
 ## v2.0.0
 
 _Feb. 23 2021_
 
 **Breaking changes**:
-* Removed all V2 (TOFIX), cops.
-  * `Metrics/LineLength` is now set to 140, with no exceptions
-  * `Lint/AmbiguousBlockAssociation` is now enabled
-  * `Naming/MemoizedInstanceVariableName` is now enabled
-  * `Naming/MethodParameterName` has had the redundant ignores removed
-  * `Style/MultilineBlockChain` is now enabled
+
+- Removed all V2 (TOFIX), cops.
+  - `Metrics/LineLength` is now set to 140, with no exceptions
+  - `Lint/AmbiguousBlockAssociation` is now enabled
+  - `Naming/MemoizedInstanceVariableName` is now enabled
+  - `Naming/MethodParameterName` has had the redundant ignores removed
+  - `Style/MultilineBlockChain` is now enabled
 
 **Fixes**:
-* Re-added in `NewCops: enabled` as this is used in rubocop 1.x as well
+
+- Re-added in `NewCops: enabled` as this is used in rubocop 1.x as well
 
 ## v1.2.0
 
 _Feb. 4 2021_
 
 **New features**:
-* Added/Amended `AllCops/Exclude` across both configurations
+
+- Added/Amended `AllCops/Exclude` across both configurations
 
 **Updates**:
-* Gem now uses v1.7 of rubocop
+
+- Gem now uses v1.7 of rubocop
 
 ## v1.1.0
 
 _Jan. 15 2021_
 
 **Updates**:
-* Gem now uses v1.3 of rubocop
+
+- Gem now uses v1.3 of rubocop
 
 ## v1.0.0
 
@@ -156,20 +176,19 @@ _Nov. 26 2020_
 
 **New features**:
 
-* Cut stable candidate of gem
-* Enforced rubocop v1.0 as a minimum as that is now stable
-* Began Semver
-* Added v2 cop plans for removal / updates
+- Cut stable candidate of gem
+- Enforced rubocop v1.0 as a minimum as that is now stable
+- Began Semver
+- Added v2 cop plans for removal / updates
 
 **Breaking changes**:
 
-* Enforce Ruby 2.7 as a minimum
+- Enforce Ruby 2.7 as a minimum
 
-* Removed/Altered some cop configurations
-  * `Layout/LineLength` now won't count rubocop in-line disables (Should try avoid this)
-  * `Metrics/MethodLength` doesn't have Max override (Tests are ignored by design)
-  * `Metrics/ClassLength` doesn't have Max override (Tests are ignored by design)
-  * `Layout/MultilineMethodCallIndentation` is no longer ignored (Was previously on specs)
-  * `Style/MixinGrouping` is no longer ignored (Was previously on specs)
-  * `Metrics/AbcSize` is no longer ignored (As we don't ignore Cyclomatic Complexity)
-  
+- Removed/Altered some cop configurations
+  - `Layout/LineLength` now won't count rubocop in-line disables (Should try avoid this)
+  - `Metrics/MethodLength` doesn't have Max override (Tests are ignored by design)
+  - `Metrics/ClassLength` doesn't have Max override (Tests are ignored by design)
+  - `Layout/MultilineMethodCallIndentation` is no longer ignored (Was previously on specs)
+  - `Style/MixinGrouping` is no longer ignored (Was previously on specs)
+  - `Metrics/AbcSize` is no longer ignored (As we don't ignore Cyclomatic Complexity)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v11.0.0
 
 - Include rubocop-performance
-- Drop ruby 2.7 support
+- Drop ruby 2.7, and 3.0 support
 - Bump dependency versions to latest
 
 ## v10.0.1

--- a/citizens-advice-style.gemspec
+++ b/citizens-advice-style.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/citizensadvice/citizens-advice-style-ruby"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 3.1.4"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/citizensadvice/citizens-advice-style-ruby"
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 1.60"
+  spec.add_dependency "rubocop", "~> 1.62"
   spec.add_dependency "rubocop-performance", "~> 1.20"
-  spec.add_dependency "rubocop-rails", "~> 2.23"
-  spec.add_dependency "rubocop-rspec", "~> 2.26"
+  spec.add_dependency "rubocop-rails", "~> 2.24"
+  spec.add_dependency "rubocop-rspec", "~> 2.27"
 end

--- a/citizens-advice-style.gemspec
+++ b/citizens-advice-style.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/citizensadvice/citizens-advice-style-ruby"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 3.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/citizensadvice/citizens-advice-style-ruby"
@@ -22,7 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 1.45"
-  spec.add_dependency "rubocop-rspec", "~> 2.18"
-  spec.add_dependency "rubocop-rails", "~> 2.17"
+  spec.add_dependency "rubocop", "~> 1.60"
+  spec.add_dependency "rubocop-performance", "~> 1.20"
+  spec.add_dependency "rubocop-rails", "~> 2.23"
+  spec.add_dependency "rubocop-rspec", "~> 2.26"
 end

--- a/default.yml
+++ b/default.yml
@@ -18,6 +18,10 @@ AllCops:
     - vendor/**/*
     - node_modules/**/*
 
+# Links and buttons should not be considered interchangeable
+Capybara/ClickLinkOrButtonStyle:
+  Enabled: false
+
 # More flexible array alignment
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent

--- a/default.yml
+++ b/default.yml
@@ -5,6 +5,7 @@ inherit_mode:
 
 require:
   - rubocop-rspec
+  - rubocop-performance
 
 AllCops:
   # Display all verbose info on failures to help people triage how to fix

--- a/lib/citizens-advice/style/version.rb
+++ b/lib/citizens-advice/style/version.rb
@@ -2,6 +2,6 @@
 
 module CitizensAdvice
   module Style
-    VERSION = "10.0.1"
+    VERSION = "11.0.0"
   end
 end


### PR DESCRIPTION
- Include "rubocop-performance"
  This is maintained by rubocop and will be included in the Rails 8 rubocop default, so it seems enougth of "a thing" to be included by default.
- Drop ruby 2.7 support
- Bump dependency versions to latest