### PR TITLE
Add missing 'rubocop-capybara' dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Citizens Advice Style Ruby
 
+## Unreleased
+
+- Gem now explicitly requires version `~> 2.19` of rubocop-capybara
+
 ## v11.0.0
 
 - Include rubocop-performance

--- a/citizens-advice-style.gemspec
+++ b/citizens-advice-style.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "~> 1.62"
+  spec.add_dependency "rubocop-capybara", "~> 2.19"
   spec.add_dependency "rubocop-performance", "~> 1.20"
   spec.add_dependency "rubocop-rails", "~> 2.24"
   spec.add_dependency "rubocop-rspec", "~> 2.27"

--- a/default.yml
+++ b/default.yml
@@ -4,6 +4,7 @@ inherit_mode:
     - Exclude
 
 require:
+  - rubocop-capybara
   - rubocop-rspec
   - rubocop-performance
 


### PR DESCRIPTION
With the recent v11.0.0 release, a line was added to default.yml to disable the `Capybara/ClickLinkOrButtonStyle` cop. This resulted in a `unrecognized cop or department Capybara/ClickLinkOrButtonStyle` error to occur in projects which didn't happen to have a dependency on a new enough version of rubocop-capybara (v2.19.0+).

Additionally, API-only Rails projects generally don't use Capybara in their test suites, so the dependency was missing altogether.

To resolve this issue, I've added `rubocop-capybara` as an explicit dependency to this gem and ensured that it is required in default.yml.